### PR TITLE
Added skeleton test examples for glm, coxph and glmerMod classes

### DIFF
--- a/tests/testthat/test_BFcoxph.R
+++ b/tests/testthat/test_BFcoxph.R
@@ -1,0 +1,8 @@
+#Test class coxph
+library(BFpack)
+library(survival)
+
+fit <- coxph(Surv(stop, event) ~ (rx + size + number) * strata(enum) +
+             cluster(id), bladder1)
+BF(fit)
+BF(fit, "rx > size = number")

--- a/tests/testthat/test_BFglm.R
+++ b/tests/testthat/test_BFglm.R
@@ -1,0 +1,11 @@
+#Test glm class object
+library(BFpack)
+
+counts <- c(18,17,15,20,10,20,25,13,12)
+outcome <- gl(3,1,9)
+treatment <- gl(3,3)
+
+glm.D93 <- glm(counts ~ outcome + treatment, family = poisson())
+
+BF(glm.D93)
+BF.glm(glm.D93, hypothesis = "treatment2 = treatment3")

--- a/tests/testthat/test_BFglmerMod.R
+++ b/tests/testthat/test_BFglmerMod.R
@@ -1,0 +1,8 @@
+#test class glmerMod
+library(BFpack)
+library(lme4)
+
+gm1 <- glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),
+                  data = cbpp, family = binomial)
+
+BF.glmerMod(gm1)


### PR DESCRIPTION
Hi Joris,

You asked me to send you some examples for these classes so that you could add them to the test files, I figured it was quicker to just add test files for them straight away. 

I looked at the structure for your other test-files and basically copied that, although it's not clear to me that your tests are testing anything since they don't contain any `test_that()` statements?