### PR TITLE
fix passing of cov.prob

### DIFF
--- a/R/BF.glm.R
+++ b/R/BF.glm.R
@@ -43,6 +43,7 @@ BF.glm <- function(x,
     Args$prior.hyp.explo <- prior.hyp.explo
     Args$complement <- complement
     Args$log <- log
+    Args$cov.prob <- cov.prob
     out <- do.call(BF, Args)
     out$model <- x
     out$call <- match.call()


### PR DESCRIPTION
this gave an error because cov.prob was missing from the Args:
```r
# logistic regression
dt <- read.csv("https://raw.githubusercontent.com/jasp-stats/jasp-desktop/development/Resources/Data%20Sets/debug.csv")
dt$facExperim <- as.factor(dt$facExperim)
test <- glm(facExperim ~ contNormal, data = dt, family = "binomial")
# BFpack:::get_estimates.glm(test)

options <- list(ciLevel = .95)
bout <- BFpack::BF(test, cov.prob = options[["ciLevel"]])
```

it does not error with the change. This is important for other packages to call the function.
